### PR TITLE
Fix indentation in proto files.

### DIFF
--- a/proto/addressmetadata.proto
+++ b/proto/addressmetadata.proto
@@ -9,31 +9,31 @@ message Header {
 // Row is an indidual piece of structured data provided by wallet authors.
 // The headers help wallets determine how to deserialize the data for their purposes.
 message MetadataField {
-	repeated Header Headers = 1;
+    repeated Header Headers = 1;
 
-	bytes Metadata = 2;
+    bytes Metadata = 2;
 }
 
 // Message is the user-specified data section of a AddressMetadata that is covered by the Signature provided by the user
 message Payload {
-	// Timestamp allows servers to determine which version of the data is the most recent.
-	int64 Timestamp = 1;
-	// User specified data.  Presumably some conventional data determined by wallet authors
-	repeated MetadataField Rows = 2;
+    // Timestamp allows servers to determine which version of the data is the most recent.
+    int64 Timestamp = 1;
+    // User specified data.  Presumably some conventional data determined by wallet authors
+    repeated MetadataField Rows = 2;
 }
 
 // AddressMetadata is the basic unit of the keytp server.  It is used in both PUT and GET requests for various keyids
 message AddressMetadata  {
-	// Serialized version of the XPubKey.  The *hash* of this XPub should correspond to the `key` in the kv store
-	bytes PubKey = 1;
-	// Signature is the signature of the metadata by XPubKey
-	bytes Signature = 2;
-	// Signature type provided.  Default is Schnorr, but can be ecdsa
-	enum SignatureType {
+    // Serialized version of the XPubKey.  The *hash* of this XPub should correspond to the `key` in the kv store
+    bytes PubKey = 1;
+    // Signature is the signature of the metadata by XPubKey
+    bytes Signature = 2;
+    // Signature type provided.  Default is Schnorr, but can be ecdsa
+    enum SignatureType {
         Schnorr = 0;
         ECDSA = 1;
     }
     SignatureType Type = 3;
-	// Payload is the metadata set by the user, and covered by the signature.
-	Payload Payload = 4;
+    // Payload is the metadata set by the user, and covered by the signature.
+    Payload Payload = 4;
 }


### PR DESCRIPTION
Summary:
Due to misconfigured editor, we got some tabs in our previous version of the file.
Herein we fix them to be spaces.

Test Plan:
Check to make sure there are no tabs