### PR TITLE
Add BIP70 Pay-For-Put support

### DIFF
--- a/pkg/payforput/payments.go
+++ b/pkg/payforput/payments.go
@@ -1,0 +1,211 @@
+package payforput
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/cashweb/keyserver/pkg/models"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/rs/zerolog/hlog"
+)
+
+// ValidatorFunc is the type of unction which can indicate if a request has
+// the appropriate headers to have been paid.
+type ValidatorFunc func(r *http.Request, secret string) bool
+
+// PaymentEnforcer ensures that the request has been paid for properly by
+// checking for a payment authorization. If there is no payment authorization
+// header, then we send a BIP70 payment request
+type PaymentEnforcer struct {
+	// Location to where we should redirect payments, and has the PaymentHandler
+	// installed
+	PaymentURL string
+	// Validator is a func that validates that a request has a valid proof of
+	// payment
+	Validator ValidatorFunc
+	// Secret is the HMAC secret used for generating and validating tokens
+	// NOTE: This may be swapped out at a later date.
+	Secret string
+}
+
+// New returns a new payment enforcer that can be used for easy BIP70 integration
+// for the keyserver.
+func New(PaymentURL string, Validator ValidatorFunc) *PaymentEnforcer {
+	pe := &PaymentEnforcer{
+		PaymentURL: PaymentURL,
+		Validator:  Validator,
+		Secret:     "",
+	}
+	if pe.Validator == nil {
+		pe.Validator = DefaultValidator
+	}
+	// Generate an ephemeral secret and hold on to it
+	if pe.Secret == "" {
+		pe.Secret = RandString(64)
+	}
+
+	return pe
+}
+
+// DefaultValidator is the default request payment validator
+func DefaultValidator(r *http.Request, secret string) bool {
+	// First attempt to get the code from the querystring
+	token := r.URL.Query().Get("code")
+
+	headerToken := r.Header.Get("Authorization")
+	// If we had an Authorization header, use that instead.
+	if headerToken != "" && len(headerToken) >= 4 && headerToken[0:4] == "POP " {
+		token = headerToken[4:]
+	}
+
+	// Remove the code query param, as it wasn't part of the HMAC hash
+	url := *r.URL
+	url.RawQuery = ""
+	// Validate that the HMAC is valid for this URL.
+	return ValidateHMACToken(url.String(), token, secret)
+}
+
+// PaymentHandler is an http handler that implements a check for payment,
+// along with a redirect to the original location with the key
+func (e *PaymentEnforcer) PaymentHandler(w http.ResponseWriter,
+	r *http.Request) {
+	log := hlog.FromRequest(r)
+	defer r.Body.Close()
+
+	// Check BIP70 headers
+	contentType := r.Header.Get("Content-Type")
+	if contentType != "application/bitcoin-payment" {
+		http.Error(w, "invalid content type", http.StatusUnsupportedMediaType)
+		return
+	}
+	acceptHeader := r.Header.Get("Accept")
+	if acceptHeader != "application/bitcoin-paymentack" {
+		http.Error(w, "invalid content type", http.StatusNotAcceptable)
+		return
+	}
+
+	// Read the Payment information
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Error().Msgf("unable to read request body: %s", err.Error())
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	payment := &models.Payment{}
+	err = proto.Unmarshal(body, payment)
+	if err != nil {
+		log.Error().Msgf("unable to unmarshal payment: %s", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	///////
+	// TODO: Check outputs
+	///////
+	log.Info().Str("memo", payment.GetMemo()).Msg("Payment received")
+
+	// Acknowledge the payment, and redirect back to the intended location.
+	memo := "Thank you for being a customer"
+	payAck := &models.PaymentACK{
+		Payment: payment,
+		Memo:    &memo,
+	}
+	payAckBytes, err := proto.Marshal(payAck)
+	if err != nil {
+		log.Error().Msgf("unable to unmarshal payment: %s", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	// Provide a payment token
+	// TODO: Maybe generate something with some metadata
+	token := GenerateHMACToken(string(payment.GetMerchantData()), e.Secret)
+	loc, err := url.Parse(string(payment.GetMerchantData()))
+	if err != nil {
+		log.Error().Msgf("unable to parse merchent data: %s", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Set up the response
+	// Add the token to the response header for ease of use.
+	q := loc.Query()
+	q.Set("code", token)
+	loc.RawQuery = q.Encode()
+	w.Header().Set("Authorization", "POP "+token)
+	w.Header().Set("Location", loc.String())
+	w.Header().Set("Pragma", "no-cache")
+	w.WriteHeader(http.StatusFound)
+	w.Write(payAckBytes)
+}
+
+// Middleware is a middleware function that ensures a payment has been made
+// before allowing this endpoint to be accessed.
+func (e *PaymentEnforcer) Middleware(prevHandler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log := hlog.FromRequest(r)
+
+		// If we have a valid payment, carry on
+		if e.Validator == nil || e.Validator(r, e.Secret) {
+			prevHandler.ServeHTTP(w, r)
+			return
+		}
+		// Close the request after we're done here.  They didn't have a valid payment yet
+		defer r.Body.Close()
+
+		// NOTE: This could just fetch an invoice from a BIP70 server, but this is
+		// straightforward for a standalone and easy to install version of this
+		// keyserver.  A lot more can be done if this becomes popular (e.g. we need peering)
+
+		// TODO: Actually create some outputs.  However, for now, ensuring we can request a
+		// payment properly is sufficient.
+
+		// Create the payment details
+		network := "main"
+		curTime := uint64(time.Now().Unix())
+		expireTime := uint64(time.Now().Add(10 * time.Second).Unix())
+		// Strip querystring since encoding and decoding might disrupt HMAC
+		url := *r.URL
+		url.RawQuery = ""
+		pd := &models.PaymentDetails{
+			Network:    &network,
+			Time:       &curTime,
+			Expires:    &expireTime,
+			PaymentUrl: &e.PaymentURL,
+			// Set the current URL to the merchant data.
+			// TODO: Probably should be more here.
+			MerchantData: []byte(url.String()),
+		}
+		// Construct and send the payment request
+		pdBytes, err := proto.Marshal(pd)
+		if err != nil {
+			log.Error().Msgf("unable to marshal request to PROTO: %s", err)
+			http.Error(w, "internal server error",
+				http.StatusInternalServerError)
+			return
+		}
+		// TODO: We need to enable this to be signed, but for that to work the
+		// server needs a valid X509 certificate.  It would probably be good to delegate obtaining
+		// an invoice from a BIP70 server.
+		pkiType := "none"
+		pdVersion := uint32(1)
+		pr := &models.PaymentRequest{
+			PaymentDetailsVersion:    &pdVersion,
+			PkiType:                  &pkiType,
+			SerializedPaymentDetails: pdBytes,
+		}
+		resp, err := proto.Marshal(pr)
+		if err != nil {
+			log.Error().Msgf("unable to marshal request to proto: %s", err)
+			http.Error(w, "internal server error",
+				http.StatusInternalServerError)
+			return
+		}
+
+		// Send the payment request
+		w.WriteHeader(http.StatusPaymentRequired)
+		w.Write(resp)
+	})
+}

--- a/pkg/payforput/payments_test.go
+++ b/pkg/payforput/payments_test.go
@@ -1,0 +1,120 @@
+package payforput
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/cashweb/keyserver/pkg/models"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnforcer(t *testing.T) {
+	assert := assert.New(t)
+
+	// Path to the key we want to update
+	keyPath := "/keys/foo"
+
+	// Create our enforcer middleware, and its endpoint
+	enforcer := New("/payments", DefaultValidator)
+	assert.NotNil(enforcer)
+
+	///////
+	// Attempt an empty put
+	br := bytes.NewBuffer([]byte(""))
+	response := httptest.NewRecorder()
+	request, err := http.NewRequest("PUT", "http://localhost:8080"+keyPath, br)
+	assert.Nil(err)
+	enforcer.Middleware(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}),
+	).ServeHTTP(response, request)
+
+	///////
+	// Check that we are required to pay after a naked PUT
+	assert.Equal(http.StatusPaymentRequired, response.Code, "StatusPaymentRequired response is expected")
+	payRequest := &models.PaymentRequest{}
+	err = proto.Unmarshal(response.Body.Bytes(), payRequest)
+	assert.Nil(err)
+	assert.Equal("none", payRequest.GetPkiType())
+	assert.Equal(uint32(1), payRequest.GetPaymentDetailsVersion())
+
+	// Check the response body is a valid payment request
+	payDetails := &models.PaymentDetails{}
+	err = proto.Unmarshal(payRequest.GetSerializedPaymentDetails(), payDetails)
+	assert.Nil(err)
+	assert.Equal("main", payDetails.GetNetwork())
+	assert.True(payDetails.GetExpires() > payDetails.GetTime())
+	assert.True(uint64(time.Now().Unix()) >= payDetails.GetTime())
+	assert.Equal("/payments", payDetails.GetPaymentUrl())
+	assert.Equal([]byte("http://localhost:8080"+keyPath), payDetails.GetMerchantData())
+
+	// Create our payment
+	payment := &models.Payment{
+		MerchantData: payDetails.GetMerchantData(),
+	}
+	paymentBytes, err := proto.Marshal(payment)
+	assert.Nil(err)
+
+	///////
+	// Check that headers are enforced on POST to the payment url
+	payBody := bytes.NewBuffer(paymentBytes)
+	response = httptest.NewRecorder()
+	request, err = http.NewRequest("POST", payDetails.GetPaymentUrl(), payBody)
+	assert.Nil(err)
+	enforcer.PaymentHandler(response, request)
+	assert.Equal(http.StatusUnsupportedMediaType, response.Code, "StatusUnsupportedMediaType response is expected")
+	///////
+	// Check that payment url gives us back a payment ack, and a token
+	request, err = http.NewRequest("POST", payDetails.GetPaymentUrl(), payBody)
+	assert.Nil(err)
+	request.Header.Add("Content-Type", "application/bitcoin-payment")
+	request.Header.Add("Accept", "application/bitcoin-paymentack")
+	response = httptest.NewRecorder()
+	enforcer.PaymentHandler(response, request)
+	assert.Equal(http.StatusFound, response.Code, "StatusFound response is expected")
+	payAck := &models.PaymentACK{}
+	err = proto.Unmarshal(response.Body.Bytes(), payAck)
+	assert.Nil(err)
+	assert.True(proto.Equal(payAck.GetPayment(), payment), "PaymentAck didn't send back payment")
+
+	// Check that the token is set correctly in both places.
+	auth := response.Header().Get("Authorization")
+	loc := response.Header().Get("Location")
+	redirectURL, err := url.Parse(loc)
+	assert.Equal(keyPath, redirectURL.Path)
+	assert.Equal("POP "+redirectURL.Query().Get("code"), auth)
+
+	///////
+	// Test that the token works with a `code` queryparam
+	br = bytes.NewBuffer([]byte(""))
+	response = httptest.NewRecorder()
+	request, err = http.NewRequest("PUT", loc, br)
+	assert.Nil(err)
+	assert.True(DefaultValidator(request, enforcer.Secret), "Token is not valid")
+	enforcer.Middleware(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.Body.Close()
+			w.WriteHeader(http.StatusOK)
+		}),
+	).ServeHTTP(response, request)
+	assert.Equal(http.StatusOK, response.Code, "StatusOK response is expected")
+
+	///////
+	// Try using as a POP token
+	response = httptest.NewRecorder()
+	request, err = http.NewRequest("PUT", "http://localhost:8080"+keyPath, br)
+	assert.Nil(err)
+	request.Header.Add("Authorization", auth)
+	assert.True(DefaultValidator(request, enforcer.Secret), "Token is not valid")
+	enforcer.Middleware(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.Body.Close()
+			w.WriteHeader(http.StatusOK)
+		}),
+	).ServeHTTP(response, request)
+	assert.Equal(http.StatusOK, response.Code, "StatusOK response is expected")
+}

--- a/pkg/payforput/token.go
+++ b/pkg/payforput/token.go
@@ -1,0 +1,61 @@
+package payforput
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"math/rand"
+)
+
+// GenerateHMACToken generates an HMAC token for a given url with the provided secret
+func GenerateHMACToken(message, secret string) string {
+	return base64.URLEncoding.EncodeToString(generateHMACTokenRaw(message, secret))
+}
+
+// ValidateHMACToken validates that an HMAC token matches for a given URL
+func ValidateHMACToken(message, messageMAC64, secret string) bool {
+	expectedMAC := generateHMACTokenRaw(message, secret)
+	messageMAC, err := base64.URLEncoding.DecodeString(messageMAC64)
+	if err != nil {
+		return false
+	}
+	return hmac.Equal(messageMAC, expectedMAC)
+}
+
+func generateHMACTokenRaw(message, secret string) []byte {
+	// Create a new HMAC by defining the hash type and the key (as byte array)
+	h := hmac.New(sha256.New, []byte(secret))
+
+	// Write Data to it
+	h.Write([]byte(message))
+
+	return h.Sum(nil)
+}
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+const (
+	letterIdxBits = 6                    // 6 bits to represent a letter index
+	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
+	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+)
+
+// RandString is a random string implementation taken from
+// https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-go
+// It implements an easy way to get an ephemeral HMAC secret if one is not configured.
+func RandString(n int) string {
+	b := make([]byte, n)
+	// A rand.Int63() generates 63 random bits, enough for letterIdxMax letters!
+	for i, cache, remain := n-1, rand.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = rand.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+
+	return string(b)
+}

--- a/pkg/payforput/token_test.go
+++ b/pkg/payforput/token_test.go
@@ -1,0 +1,18 @@
+package payforput
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateVerifyToken(t *testing.T) {
+	assert := assert.New(t)
+	secret := RandString(64)
+	message := RandString(64)
+
+	token := GenerateHMACToken(message, secret)
+	assert.True(ValidateHMACToken(message, token, secret))
+	assert.False(ValidateHMACToken("not the message", token, secret))
+	assert.False(ValidateHMACToken(message, token, "not the secret"))
+}


### PR DESCRIPTION
Summary:
The current state of this server is that you can put to keys which are the
Bitcoin(Cash) address that you control the private key for.  However, the result
of this alone will mean that nefarious parties will spam the server with PUTs for
various randomly generated keys in order to make running a server prohibitively
expensive.

Thus, this commit implements the start of a method for asking for BIP70 payment
upon the receipt of a PUT request.  The basic flow is:

1. Client attempts PUT /keys/<key> with an empty request body.
2. Server response with Status 402 (Payment Required) with a BIP70 payment details
  in the response body.  Payment details has the URL in the merchant data field.
3. Client generates a Payment and sends it to the pay_to field from the payment request.
4. Payment address validates the Payment and generates a Proof of Payment(PoP) Token.
  It responds with a HTTP 302 back to the original URL, a receipt token in the "Authorization"
  header, and a "Location" header with a "code" query-string amended to it with the PoP token.
5. Client follows the redirect, and PUTs the data it intended to put.

Implements #6

Test Plan:
go test ./...