### PR TITLE
Use Unix() instead of UnixNano() in tests

### DIFF
--- a/pkg/keytp/handlers_test.go
+++ b/pkg/keytp/handlers_test.go
@@ -30,7 +30,7 @@ func TestSetKey(t *testing.T) {
 	addrMetadata := &models.AddressMetadata{
 		PubKey: pubkey.SerializeUncompressed(),
 		Payload: &models.Payload{
-			Timestamp: time.Now().UnixNano(),
+			Timestamp: time.Now().Unix(),
 			Rows: []*models.MetadataField{
 				&models.MetadataField{
 					Headers: []*models.Header{
@@ -78,7 +78,7 @@ func TestGetKey(t *testing.T) {
 	addrMetadata := &models.AddressMetadata{
 		PubKey: pubkey.SerializeUncompressed(),
 		Payload: &models.Payload{
-			Timestamp: time.Now().UnixNano(),
+			Timestamp: time.Now().Unix(),
 			Rows: []*models.MetadataField{
 				&models.MetadataField{
 					Headers: []*models.Header{


### PR DESCRIPTION
Summary:
While the server currently does not apply any meaning to the timestamp (beyond that
they be sequentially defined) we want to eventually introduce a time-to-live for these
keys.  Therefore, swap the tests to use Unix() instead of UnixNano() as sub-second resolution
is not needed.

Test Plan:
`go test ./...`