### PR TITLE
Update gitignore to include k8s folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+k8s/
+vendor/
 
 .DS_Store
 


### PR DESCRIPTION
Summary:
Update the gitignore file to filter out some infrastructure items that are not relevant to the open source repository.