### PR TITLE
Ensure content type is set for payment requests

### DIFF
--- a/pkg/payforput/payments.go
+++ b/pkg/payforput/payments.go
@@ -77,12 +77,12 @@ func (e *PaymentEnforcer) PaymentHandler(w http.ResponseWriter,
 
 	// Check BIP70 headers
 	contentType := r.Header.Get("Content-Type")
-	if contentType != "application/bitcoin-payment" {
+	if contentType != "application/bitcoincash-payment" {
 		http.Error(w, "invalid content type", http.StatusUnsupportedMediaType)
 		return
 	}
 	acceptHeader := r.Header.Get("Accept")
-	if acceptHeader != "application/bitcoin-paymentack" {
+	if acceptHeader != "application/bitcoincash-paymentack" {
 		http.Error(w, "invalid content type", http.StatusNotAcceptable)
 		return
 	}
@@ -205,6 +205,8 @@ func (e *PaymentEnforcer) Middleware(prevHandler http.Handler) http.Handler {
 		}
 
 		// Send the payment request
+                w.Header().Set("Content-Type", "application/bitcoincash-paymentrequest")
+                w.Header().Set("Content-Transfer-Encoding", "binary")
 		w.WriteHeader(http.StatusPaymentRequired)
 		w.Write(resp)
 	})

--- a/pkg/payforput/payments_test.go
+++ b/pkg/payforput/payments_test.go
@@ -36,6 +36,7 @@ func TestEnforcer(t *testing.T) {
 	///////
 	// Check that we are required to pay after a naked PUT
 	assert.Equal(http.StatusPaymentRequired, response.Code, "StatusPaymentRequired response is expected")
+	assert.Equal("application/bitcoincash-paymentrequest", response.Header().Get("Content-Type"), "Invalid content type.")
 	payRequest := &models.PaymentRequest{}
 	err = proto.Unmarshal(response.Body.Bytes(), payRequest)
 	assert.Nil(err)
@@ -71,8 +72,8 @@ func TestEnforcer(t *testing.T) {
 	// Check that payment url gives us back a payment ack, and a token
 	request, err = http.NewRequest("POST", payDetails.GetPaymentUrl(), payBody)
 	assert.Nil(err)
-	request.Header.Add("Content-Type", "application/bitcoin-payment")
-	request.Header.Add("Accept", "application/bitcoin-paymentack")
+	request.Header.Add("Content-Type", "application/bitcoincash-payment")
+	request.Header.Add("Accept", "application/bitcoincash-paymentack")
 	response = httptest.NewRecorder()
 	enforcer.PaymentHandler(response, request)
 	assert.Equal(http.StatusFound, response.Code, "StatusFound response is expected")


### PR DESCRIPTION
Summary:
The BIP70 spec omits the content-type header requirement for payment requests.
However, BIP71 does indeed include the mime type.  This commit adds this information
to the responses in the payforput middleware.

See:
https://github.com/bitcoin/bips/blob/master/bip-0071.mediawiki
https://lists.linuxfoundation.org/pipermail/bitcoin-ml/2017-August/000178.html

Test Plan:
```
go test ./...
```