### PR TITLE
Implement CI tests using Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: go
+
+env:
+  global:
+    - GO111MODULE: "on"
+    - GOFLAGS: "-mod=readonly"
+    - GOPROXY: https://proxy.golang.org
+
+go:
+  - 1.13.x
+  - tip
+
+stages:
+  - diff
+  - test
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - go: tip
+
+before_install: go get -u github.com/kyoh86/richgo
+
+script:
+  - richgo test -v ./...
+  - diff -u <(echo -n) <(gofmt -d -s .)
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/pkg/keydb/keydb_test.go
+++ b/pkg/keydb/keydb_test.go
@@ -53,10 +53,10 @@ func TestSetGetTTL(t *testing.T) {
 			Timestamp: time.Now().Add(-2 * time.Second).Unix(),
 			Ttl:       1,
 			Entries: []*models.Entry{
-				&models.Entry{
+				{
 					Kind: "EgoBoost",
 					Headers: []*models.Header{
-						&models.Header{
+						{
 							Name:  "Junk",
 							Value: "Data",
 						},

--- a/pkg/keytp/handlers_test.go
+++ b/pkg/keytp/handlers_test.go
@@ -32,10 +32,10 @@ func TestSetKey(t *testing.T) {
 		Payload: &models.Payload{
 			Timestamp: time.Now().Unix(),
 			Entries: []*models.Entry{
-				&models.Entry{
+				{
 					Kind: "EgoBoost",
 					Headers: []*models.Header{
-						&models.Header{
+						{
 							Name:  "Junk",
 							Value: "Data",
 						},
@@ -81,10 +81,10 @@ func TestGetKey(t *testing.T) {
 		Payload: &models.Payload{
 			Timestamp: time.Now().Unix(),
 			Entries: []*models.Entry{
-				&models.Entry{
+				{
 					Kind: "EgoBoost",
 					Headers: []*models.Header{
-						&models.Header{
+						{
 							Name:  "Junk",
 							Value: "Data",
 						},

--- a/pkg/payforput/payments.go
+++ b/pkg/payforput/payments.go
@@ -205,8 +205,8 @@ func (e *PaymentEnforcer) Middleware(prevHandler http.Handler) http.Handler {
 		}
 
 		// Send the payment request
-                w.Header().Set("Content-Type", "application/bitcoincash-paymentrequest")
-                w.Header().Set("Content-Transfer-Encoding", "binary")
+		w.Header().Set("Content-Type", "application/bitcoincash-paymentrequest")
+		w.Header().Set("Content-Transfer-Encoding", "binary")
 		w.WriteHeader(http.StatusPaymentRequired)
 		w.Write(resp)
 	})


### PR DESCRIPTION
Addresses #14 

- Run `go fmt` on the proposed changes
  - Fixes formatting issues found by `go fmt`
- Using `richgo` run go tests
- allow fast finish for Travis tests
  - Because we want to catch errors on golang TIP but not to allow
     tests/builds on TIP to fail, we allow fast finish to show pass/fail
     w/o waiting for one that may always fail.

Signed-off-by: Matt Welch <matt.welch@gmail.com>